### PR TITLE
feat(tests): Mock Ptolemy

### DIFF
--- a/ptolemy-py/python/ptolemy_client/__init__.py
+++ b/ptolemy-py/python/ptolemy_client/__init__.py
@@ -2,7 +2,8 @@
 
 # pylint: disable=no-name-in-module
 
-from .client import connect, Ptolemy
+from .client.client import Ptolemy, connect
+from .trace import Trace
 
 # Used by python-semantic-release
 __version__ = "0.0.0-test.4+7da95d5"

--- a/ptolemy-py/python/ptolemy_client/client/base.py
+++ b/ptolemy-py/python/ptolemy_client/client/base.py
@@ -14,10 +14,8 @@ from ..trace import Trace
 class PtolemyBase(BaseModel, ABC):
     @abstractmethod
     def add_trace_blocking(self, trace: "Trace"): ...
-    
     @abstractmethod
     async def add_trace(self, trace: "Trace"): ...
-    
     def trace(
         self,
         subject_id: UUID,

--- a/ptolemy-py/python/ptolemy_client/client/base.py
+++ b/ptolemy-py/python/ptolemy_client/client/base.py
@@ -39,5 +39,11 @@ class PtolemyBase(BaseModel, ABC):
             environment=environment,
         )
 
-# NOTE: Required to avoid Pydantic error
+# Pydantic forward-ref resolution:
+# Trace.client is annotated as type "PtolemyBase", but at import time Trace was
+# defined before PtolemyBase was available in its namespace. Because we use
+# `from __future__ import annotations`, Pydantic stores that annotation as a string
+# and cannot resolve it automatically. After both classes are defined, we call
+# `Trace.model_rebuild()` with a namespace mapping so Pydantic can resolve the
+# forward reference and validate instances correctly at runtime.
 Trace.model_rebuild()

--- a/ptolemy-py/python/ptolemy_client/client/base.py
+++ b/ptolemy-py/python/ptolemy_client/client/base.py
@@ -1,0 +1,43 @@
+"""Ptolemy Client."""
+
+from __future__ import annotations
+
+from typing import Optional
+from abc import ABC, abstractmethod
+from uuid import UUID
+from pydantic import BaseModel
+
+from ..tier import Tier
+from ..io import Parameters
+from ..trace import Trace
+
+class PtolemyBase(BaseModel, ABC):
+    @abstractmethod
+    def add_trace_blocking(self, trace: "Trace"): ...
+    
+    @abstractmethod
+    async def add_trace(self, trace: "Trace"): ...
+    
+    def trace(
+        self,
+        subject_id: UUID,
+        name: str,
+        parameters: Optional[Parameters],
+        version: Optional[str] = None,
+        environment: Optional[str] = None,
+    ) -> "Trace":
+        """Create new trace."""
+
+        return Trace(
+            client=self,
+            tier=Tier.SYSTEM,
+            subject_id=subject_id,
+            parent_id=subject_id,
+            name=name,
+            parameters=parameters,
+            version=version,
+            environment=environment,
+        )
+
+# NOTE: Required to avoid Pydantic error
+Trace.model_rebuild()

--- a/ptolemy-py/python/ptolemy_client/client/client.py
+++ b/ptolemy-py/python/ptolemy_client/client/client.py
@@ -1,0 +1,54 @@
+"""Ptolemy Client."""
+
+from __future__ import annotations
+
+import logging
+from pydantic import InstanceOf
+
+from .base import PtolemyBase
+from .._core import RecordExporter
+from ..trace import Trace
+
+logger = logging.getLogger(__name__)
+
+class Ptolemy(PtolemyBase):
+    """Ptolemy Client."""
+
+    base_url: str
+
+    client: InstanceOf[RecordExporter]
+
+    def add_trace_blocking(self, trace: "Trace"):
+        """Send trace."""
+        # TODO: Batching, retries, etc.
+
+        try:
+            self.client.send_trace_blocking(trace)
+        # Thrown when invalid trace is sent
+        except AttributeError as e:
+            logger.error("Invalid trace type: %s", trace.__class__.__name__)
+        except ConnectionError as e:
+            logger.error("Error sending trace %s: %s", trace.id_, e)
+
+    async def add_trace(self, trace: "Trace"):
+        """Send trace."""
+        # TODO: Batching, retries, etc.
+
+        try:
+            await self.client.send_trace(trace)
+        # Thrown when invalid trace is sent
+        except AttributeError as e:
+            logger.error("Invalid trace type: %s", trace.__class__.__name__)
+        except ConnectionError as e:
+            logger.error("Error sending trace %s: %s", trace.id_, e)
+
+def connect(base_url: str) -> Ptolemy:
+    """
+    Connect to Ptolemy client.
+    """
+    client = RecordExporter(base_url)
+
+    return Ptolemy(
+        base_url=base_url,
+        client=client,
+    )

--- a/ptolemy-py/python/ptolemy_client/client/mock.py
+++ b/ptolemy-py/python/ptolemy_client/client/mock.py
@@ -1,0 +1,20 @@
+"""Ptolemy Client."""
+
+from __future__ import annotations
+
+from typing import List
+from pydantic import Field
+
+from .base import PtolemyBase
+from ..trace import Trace
+
+class MockPtolemy(PtolemyBase):
+    """Mock Ptolemy class."""
+
+    traces: List["Trace"] = Field(default_factory=list)
+
+    def add_trace_blocking(self, trace: "Trace"):
+        self.traces.append(trace)
+
+    async def add_trace(self, trace: "Trace"):
+        self.traces.append(trace)

--- a/ptolemy-py/python/ptolemy_client/io.py
+++ b/ptolemy-py/python/ptolemy_client/io.py
@@ -1,7 +1,6 @@
 """IO Models."""
 
-from typing import TypeVar, Generic, Optional
-import time
+from typing import TypeVar, Generic, Optional, Dict, Any
 from uuid import UUID, uuid4
 from pydantic import BaseModel, Field, field_validator
 from ._core import validate_field_value
@@ -10,6 +9,8 @@ T = TypeVar("T")
 
 # TODO: Eventually make this configurable
 MAX_SIZE = 1024
+
+Parameters = Dict[str, Any]
 
 class IO(BaseModel, Generic[T]):
     """IO object."""

--- a/ptolemy-py/tests/test_trace.py
+++ b/ptolemy-py/tests/test_trace.py
@@ -1,0 +1,37 @@
+"""Test Trace functionality."""
+
+from uuid import uuid4
+import pytest
+from ptolemy_client.client.mock import MockPtolemy
+from ptolemy_client.tier import Tier
+
+@pytest.fixture
+def client() -> MockPtolemy:
+    return MockPtolemy()
+
+def test_trace_subject_id(client: MockPtolemy):
+    trace = client.trace(
+        uuid4(), # subject_id
+        "my_system_trace",
+        parameters={"foo": "bar"},
+        version="0.0.1",
+        environment="DEV"
+    )
+    
+    assert trace.subject_id == trace.parent_id
+    assert trace.tier == Tier.SYSTEM
+
+def test_trace_child(client: MockPtolemy):
+    trace = client.trace(
+        uuid4(), # subject_id
+        "my_system_trace",
+        parameters={"foo": "bar"},
+        version="0.0.1",
+        environment="DEV"
+    )
+    
+    child = trace.child("child", parameters={"foo": "bar"}, version="0.0.1", environment="DEV")
+    
+    assert child.subject_id == trace.subject_id
+    assert child.parent_id == trace.id_
+    assert child.tier == Tier.SUBSYSTEM

--- a/ptolemy-py/tests/test_trace.py
+++ b/ptolemy-py/tests/test_trace.py
@@ -11,27 +11,29 @@ def client() -> MockPtolemy:
 
 def test_trace_subject_id(client: MockPtolemy):
     trace = client.trace(
-        uuid4(), # subject_id
+        uuid4(),  # subject_id
         "my_system_trace",
         parameters={"foo": "bar"},
         version="0.0.1",
-        environment="DEV"
+        environment="DEV",
     )
-    
+
     assert trace.subject_id == trace.parent_id
     assert trace.tier == Tier.SYSTEM
 
 def test_trace_child(client: MockPtolemy):
     trace = client.trace(
-        uuid4(), # subject_id
+        uuid4(),  # subject_id
         "my_system_trace",
         parameters={"foo": "bar"},
         version="0.0.1",
-        environment="DEV"
+        environment="DEV",
     )
-    
-    child = trace.child("child", parameters={"foo": "bar"}, version="0.0.1", environment="DEV")
-    
+
+    child = trace.child(
+        "child", parameters={"foo": "bar"}, version="0.0.1", environment="DEV"
+    )
+
     assert child.subject_id == trace.subject_id
     assert child.parent_id == trace.id_
     assert child.tier == Tier.SUBSYSTEM


### PR DESCRIPTION
## Description
- Adds `PtolemyBaseClass` (from which `MockPtolemy` and `Ptolemy` inherit)
- Adds a `MockPtolemy` class for unit tests
- Adds unit tests for `MockPtolemy.trace` function

Tests for `Ptolemy` will be adde3d in #336

## Alternatives Considered

- Doing this on the Rust side was considered, but inheritance gets hair *very* quickly
- Standard mocking (using `AsyncMock` and `MagicMock`) doesn't play well with Pydantic which gives you a hard time if you try to replace functions

Having a dedicated `MockPtolemy` class will be useful for users looking to test functionality without running a `Ptolemy` instance.
